### PR TITLE
fix HTTPSRedirectHandler to not fail if url.Host doesn't have a port

### DIFF
--- a/https_redirect.go
+++ b/https_redirect.go
@@ -18,12 +18,7 @@ func (h *HTTPSRedirectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 		url := *req.URL
 		url.Scheme = "https"
 
-		host, _, err := net.SplitHostPort(url.Host)
-		if err != nil {
-			internal.BadRequestHandler(rw, req, err)
-			return
-		}
-
+		host := url.Hostname()
 		if h.Port != 0 && h.Port != 443 {
 			port := fmt.Sprintf("%v", h.Port)
 			url.Host = net.JoinHostPort(host, port)

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -1,8 +1,0 @@
-package internal
-
-import "net/http"
-
-// BadRequestHandler renders and 400 response with an error
-func BadRequestHandler(rw http.ResponseWriter, _ *http.Request, err error) {
-	http.Error(rw, err.Error(), http.StatusBadRequest)
-}


### PR DESCRIPTION
great catch @karasz 